### PR TITLE
feat: adding history route and back to home button

### DIFF
--- a/src/app/components/InlineTextArea/styles.module.scss
+++ b/src/app/components/InlineTextArea/styles.module.scss
@@ -8,8 +8,9 @@
   font-size: $large;
 }
 .spanContainer {
-  width: 30rem;
   min-height: 300px;
+  width: 30rem;
+  word-wrap: break-word;
   @media #{$mobile} {
     height: 100%;
     width: 100%;

--- a/src/app/components/Topbar/index.js
+++ b/src/app/components/Topbar/index.js
@@ -3,6 +3,7 @@ import { UTLabel, UTButton } from '@widergy/energy-ui';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { useLocation } from 'react-router';
+import i18 from 'i18next';
 
 import logo from 'app/assets/logoBlanco.png';
 import { HOME } from 'constants/routes';
@@ -17,11 +18,11 @@ const Topbar = ({ dispatch }) => {
   return (
     <div className={styles.container}>
       <UTLabel bold large white>
-        Abloc de Notas
+        {i18.t('Topbar:title')}
       </UTLabel>
-      {pathName !== '/' && pathName !== '/home' && (
+      {![HOME, '/home'].includes(pathName) && (
         <UTButton className={styles.backButton} onPress={goToHome}>
-          ↩ Home
+          {i18.t('Topbar:backHomeButton')}
         </UTButton>
       )}
       <img alt="logo" src={logo} className={styles.logo} onKeyDown={goToHome} onClick={goToHome} />

--- a/src/app/components/Topbar/index.js
+++ b/src/app/components/Topbar/index.js
@@ -1,17 +1,32 @@
-import React from 'react';
-import { UTLabel } from '@widergy/energy-ui';
+import React, { useCallback } from 'react';
+import { UTLabel, UTButton } from '@widergy/energy-ui';
+import { connect } from 'react-redux';
+import { push } from 'connected-react-router';
+import { useLocation } from 'react-router';
 
 import logo from 'app/assets/logoBlanco.png';
+import { HOME } from 'constants/routes';
 
 import styles from './styles.module.scss';
 
-const Topbar = () => (
-  <div className={styles.container}>
-    <UTLabel bold large white>
-      Abloc de Notas
-    </UTLabel>
-    <img alt="logo" src={logo} className={styles.logo} />
-  </div>
-);
+const Topbar = ({ dispatch }) => {
+  const goToHome = useCallback(() => dispatch(push(HOME), [dispatch]));
 
-export default Topbar;
+  const pathName = useLocation().pathname;
+
+  return (
+    <div className={styles.container}>
+      <UTLabel bold large white>
+        Abloc de Notas
+      </UTLabel>
+      {pathName !== '/' && pathName !== '/home' && (
+        <UTButton className={styles.backButton} onPress={goToHome}>
+          ↩ Home
+        </UTButton>
+      )}
+      <img alt="logo" src={logo} className={styles.logo} onKeyDown={goToHome} onClick={goToHome} />
+    </div>
+  );
+};
+
+export default connect()(Topbar);

--- a/src/app/components/Topbar/styles.module.scss
+++ b/src/app/components/Topbar/styles.module.scss
@@ -30,7 +30,7 @@ $shadow: 0 0 7px 0 rgba(122, 122, 122, 0.81);
   color: $white;
   padding: 0 10px 0 10px;
   margin: -8px 0 0 -20px;
-  align-self: start;
+  align-self: flex-start;
   min-width: fit-content !important;
 }
 

--- a/src/app/components/Topbar/styles.module.scss
+++ b/src/app/components/Topbar/styles.module.scss
@@ -1,4 +1,5 @@
 @import 'scss/variables/_sizes.scss';
+@import 'scss/variables/_fontSizes.scss';
 @import '_colors.scss';
 
 $shadow: 0 0 7px 0 rgba(122, 122, 122, 0.81);
@@ -14,6 +15,25 @@ $shadow: 0 0 7px 0 rgba(122, 122, 122, 0.81);
   width: 100%;
 }
 
+.container img {
+  margin-left: auto;
+}
+
 .logo {
   height: calc(#{$topbar-heigth} - 40px);
+  cursor: pointer;
+}
+
+.backButton {
+  font-size: $small * 0.9 !important;
+  background-color: #ff6363 !important;
+  color: $white;
+  padding: 0 10px 0 10px;
+  margin: -8px 0 0 -20px;
+  align-self: start;
+  min-width: fit-content !important;
+}
+
+.backButton:hover {
+  background-color: #c54a4a !important;
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -3,22 +3,24 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 import { ConnectedRouter } from 'connected-react-router';
 
 import { history } from 'redux/store';
-import { HOME, QUOTES, BLOC } from 'constants/routes';
+import { HOME, QUOTES, BLOC, HISTORY } from 'constants/routes';
 
 import Topbar from './components/Topbar';
 import Home from './screens/Home';
 import Quotes from './screens/Quotes';
 import Bloc from './screens/Bloc';
+import History from './screens/History';
 import styles from './styles.module.scss';
 
 const App = () => (
   <div className={styles.container}>
-    <Topbar />
     <ConnectedRouter history={history}>
+      <Topbar />
       <Switch>
         <Route exact path={HOME} component={Home} />
         <Route exact path={QUOTES} component={Quotes} />
         <Route exact path={BLOC} component={Bloc} />
+        <Route exact path={HISTORY} component={History} />
         <Route render={() => <Redirect to={HOME} />} />
       </Switch>
     </ConnectedRouter>

--- a/src/app/screens/History/index.js
+++ b/src/app/screens/History/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import styles from './styles.module.scss';
+
+const History = () => {
+  console.log('boca');
+  return <div className={styles.container}>HISTORY</div>;
+};
+
+export default connect()(History);

--- a/src/app/screens/History/index.js
+++ b/src/app/screens/History/index.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import styles from './styles.module.scss';
 
 const History = () => {
-  console.log('boca');
   return <div className={styles.container}>HISTORY</div>;
 };
 

--- a/src/app/screens/History/styles.module.scss
+++ b/src/app/screens/History/styles.module.scss
@@ -1,4 +1,7 @@
 @import 'scss/variables/_sizes.scss';
+@import 'scss/variables/_fontSizes.scss';
+@import 'scss/variables/_mediaQueries.scss';
+@import '_general.scss';
 @import '_colors.scss';
 
 .container {
@@ -9,19 +12,11 @@
   justify-content: flex-start;
   padding: 40px 20px;
   width: 100%;
-}
 
-.action {
-  margin: 40px;
-}
+  width: 100%;
 
-.buttonContainer {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-}
-
-.buttonContainer button {
-  margin: 0 5px 0 5px;
+  @media #{$mobile} {
+    height: 200px;
+    width: 100%;
+  }
 }

--- a/src/app/screens/Home/index.js
+++ b/src/app/screens/Home/index.js
@@ -4,12 +4,13 @@ import { push } from 'connected-react-router';
 import { UTButton, UTLabel } from '@widergy/energy-ui';
 import i18 from 'i18next';
 
-import { BLOC } from 'constants/routes';
+import { BLOC, HISTORY } from 'constants/routes';
 
 import styles from './styles.module.scss';
 
 const Home = ({ dispatch }) => {
   const goToBloc = useCallback(() => dispatch(push(BLOC), [dispatch]));
+  const goToHistory = useCallback(() => dispatch(push(HISTORY), [dispatch]));
 
   return (
     <div className={styles.container}>
@@ -17,7 +18,10 @@ const Home = ({ dispatch }) => {
         {i18.t('Home:title')}
       </UTLabel>
       <UTLabel className={styles.action}>{i18.t('Home:subtitle')}</UTLabel>
-      <UTButton onPress={goToBloc}>{i18.t('Home:blocButton')}</UTButton>
+      <div className={styles.buttonContainer}>
+        <UTButton onPress={goToBloc}>{i18.t('Home:blocButton')}</UTButton>
+        <UTButton onPress={goToHistory}>{i18.t('Home:historyButton')}</UTButton>
+      </div>
     </div>
   );
 };

--- a/src/config/someCustomer/texts.js
+++ b/src/config/someCustomer/texts.js
@@ -1,5 +1,9 @@
 export default {
   es: {
+    Topbar: {
+      title: 'Abloc de Notas',
+      backHomeButton: '↩ Home'
+    },
     Home: {
       title: 'Bienvenido al bloc de notas del training de ABOT',
       subtitle: 'Presioná el botón para continuar',
@@ -21,6 +25,7 @@ export default {
         words: 'Palabras'
       }
     },
+    History: {},
     DefaultMessages: {
       getQuotesFailure: 'Hubo un error al recuperar los personajes!'
     }

--- a/src/config/someCustomer/texts.js
+++ b/src/config/someCustomer/texts.js
@@ -4,7 +4,8 @@ export default {
       title: 'Bienvenido al bloc de notas del training de ABOT',
       subtitle: 'Presioná el botón para continuar',
       button: 'Continuar',
-      blocButton: 'Ver bloc de notas'
+      blocButton: 'Ver bloc de notas',
+      historyButton: 'Ver historial'
     },
     Quotes: {
       formContent: 'Cuantos personajes deseas recuperar?',

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,3 +1,4 @@
 export const HOME = '/';
 export const QUOTES = '/quotes';
 export const BLOC = '/bloc-de-notas';
+export const HISTORY = '/history';


### PR DESCRIPTION
# Ading history route

### By pressing the "show history" button we will be redirected to the "/history" path

![image](https://user-images.githubusercontent.com/96079880/149385596-4c62f0b1-fbcf-4e27-a8f2-93f4865b8ea6.png)

### For now, this path is empty, but we can see the new button "back to the home page".

![image](https://user-images.githubusercontent.com/96079880/149385749-967b4691-195b-441d-9b18-b366e2b5ab4c.png)

![image](https://user-images.githubusercontent.com/96079880/149385812-20e80787-4747-4a2e-b403-ff3c216b1f41.png)

### Also now the Widergy's logo it's a link who redirect us to home

![image](https://user-images.githubusercontent.com/96079880/149398486-0d51ec50-496e-46de-b7bb-6d0ef9ab38a3.png)
